### PR TITLE
Bugfix: Pubmed now only serves content from HTTPS

### DIFF
--- a/src/PubMed/PubMed.php
+++ b/src/PubMed/PubMed.php
@@ -140,6 +140,7 @@ abstract class PubMed
     curl_setopt($this->curl, CURLOPT_CONNECTTIMEOUT, $this->connectionTimeout);
     curl_setopt($this->curl, CURLOPT_TIMEOUT, $this->timeout);
     curl_setopt($this->curl, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($this->curl, CURLOPT_FOLLOWLOCATION, true);
 
     $rs = curl_exec($this->curl);
     $curl_error = curl_error($this->curl);

--- a/src/PubMed/PubMedId.php
+++ b/src/PubMed/PubMedId.php
@@ -21,7 +21,7 @@ class PubMedId extends PubMed
    */
   protected function getUrl()
   {
-    return 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi';
+    return 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi';
   }
 
   /**

--- a/src/PubMed/Term.php
+++ b/src/PubMed/Term.php
@@ -21,7 +21,7 @@ class Term extends PubMed
    */
   protected function getUrl()
   {
-    return 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi';
+    return 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi';
   }
 
   /**


### PR DESCRIPTION
Bugfix: Pubmed now only serves content from HTTPS
Also, follow redirects by default.