### PR TITLE
Updated Article.php for pubYear, doi and pii fetching

### DIFF
--- a/src/PubMed/Article.php
+++ b/src/PubMed/Article.php
@@ -121,7 +121,16 @@ class Article
    */
   public function getDoid()
   {
-      return (string) $this->xml->ELocationID[1];
+    $ELocationID = "";
+    if (isset($this->xml->ELocationID)) {
+      foreach ($this->xml->ELocationID as $uid) {
+        if (preg_match('/^10.\d{4,9}\//', $uid)) {
+          $ELocationID = (string) $uid;
+        }
+      }
+    }
+
+    return $ELocationID;
   }
 
   /**
@@ -129,7 +138,16 @@ class Article
    */
   public function getPii()
   {
-      return (string) $this->xml->ELocationID[0];
+      $pii = "";
+      if (isset($this->xml->ELocationID)) {
+          foreach ($this->xml->ELocationID as $uid) {
+              if (!preg_match('/^10.\d{4,9}\//', $uid)) {
+                  $pii = (string) $uid;
+              }
+          }
+      }
+
+      return $pii;
   }
 
   /**
@@ -156,7 +174,16 @@ class Article
    */
   public function getPubYear()
   {
-    return (string) $this->xml->Journal->JournalIssue->PubDate->Year;
+      if (!empty($this->xml->Journal->JournalIssue->PubDate->Year)) {
+          return (string) $this->xml->Journal->JournalIssue->PubDate->Year;
+      } else {
+          $pubDate = (string) $this->xml->Journal->JournalIssue->PubDate->MedlineDate;
+          if (preg_match('/^\d\d\d\d/', $pubDate)) {
+              return substr($pubDate, 0, 4);
+          } else {
+              return (string) $this->xml->ArticleDate->Year;
+          }
+      }
   }
 
   /**


### PR DESCRIPTION
I have made changes to 3 functions in Article.php:

- getPubYear(). In case JournalIssue/PubDate/Year tag is not present (e.g., PMID 2342890), get the value from MedlineDate. 

- getDoid() and getPii(). Since ELocationID element houses DOIs or PIIs only, and DOIs have certain patterns to match, I used regular expression to determine if the value is for DOI or PII, and fetched them accordingly.

Thanks!